### PR TITLE
Fix Linux crash when device resolution differs from requested

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -271,7 +271,7 @@ class _CameraAppState extends State<CameraApp> {
                   onPressed: _isCapturing ? null : () => _startCamera(),
                   child: const Text('Start'),
                 ),
-                // Start Button
+                // Switch Camera Button
                 ElevatedButton(
                   onPressed: devices.isEmpty ? null : () => _nextCamera(),
                   child: Text('Switch Camera ($_currentName)'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,7 +46,7 @@ class _CameraAppState extends State<CameraApp> {
 
   String get _currentName {
     if (_currentCamera < devices.length && _currentCamera > -1) {
-      return devices[_currentCamera] ?? '';
+      return devices[_currentCamera];
     }
     return '';
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,6 +33,7 @@ class _CameraAppState extends State<CameraApp> {
   bool _isCapturing = false;
   int _width = 640;
   int _height = 480;
+  int _currentCamera = 0;
   ui.Image? _latestFrame;
   bool _shouldCapture = false;
   FlutterBarcodeSdk? _barcodeReader;
@@ -41,6 +42,14 @@ class _CameraAppState extends State<CameraApp> {
       'DLS2eyJoYW5kc2hha2VDb2RlIjoiMjAwMDAxLTE2NDk4Mjk3OTI2MzUiLCJvcmdhbml6YXRpb25JRCI6IjIwMDAwMSIsInNlc3Npb25QYXNzd29yZCI6IndTcGR6Vm05WDJrcEQ5YUoifQ==';
   bool isDecoding = false;
   List<BarcodeResult>? results;
+  List<String> devices = [];
+
+  String get _currentName {
+    if (_currentCamera < devices.length && _currentCamera > -1) {
+      return devices[_currentCamera] ?? '';
+    }
+    return '';
+  }
 
   @override
   void initState() {
@@ -57,14 +66,40 @@ class _CameraAppState extends State<CameraApp> {
     await _barcodeReader!.init();
   }
 
+  Future<void> _nextCamera() async {
+    await _stopCamera();
+    _currentCamera++;
+    await _startCamera();
+  }
+
+  Future<int?> _openCamera(int startFrom) async {
+    if (devices.isEmpty) {
+      return null;
+    }
+    int current = startFrom % devices.length;
+    while (true) {
+      print("Opening camera $current (${devices[current]??'null'})})");
+      bool opened = await _flutterLiteCameraPlugin.open(current);
+      if (opened) {
+        print("Camera $current is now open");
+        return current;
+      }
+
+      current = (current + 1) % devices.length;
+      if (current == startFrom) {
+        return null;
+      }
+    }
+  }
+
   Future<void> _startCamera() async {
     try {
-      List<String> devices = await _flutterLiteCameraPlugin.getDeviceList();
+      devices = await _flutterLiteCameraPlugin.getDeviceList();
       if (devices.isNotEmpty) {
         print("Available Devices: $devices");
-        print("Opening camera 0");
-        bool opened = await _flutterLiteCameraPlugin.open(0);
-        if (opened) {
+        int? opened = await _openCamera(_currentCamera);
+        if (opened != null) {
+          _currentCamera = opened;
           setState(() {
             _isCameraOpened = true;
             _shouldCapture = true;
@@ -110,7 +145,11 @@ class _CameraAppState extends State<CameraApp> {
         await _convertBufferToImage(rgbBuffer, frame['width'], frame['height']);
       }
     } catch (e) {
-      // print("Error capturing frame: $e");
+      print("Error capturing frame: $e");
+      _shouldCapture = false;
+      setState(() {
+        _isCapturing = false;
+      });
     }
 
     // Schedule the next frame
@@ -231,6 +270,11 @@ class _CameraAppState extends State<CameraApp> {
                 ElevatedButton(
                   onPressed: _isCapturing ? null : () => _startCamera(),
                   child: const Text('Start'),
+                ),
+                // Start Button
+                ElevatedButton(
+                  onPressed: devices.isEmpty ? null : () => _nextCamera(),
+                  child: Text('Switch Camera ($_currentName)'),
                 ),
                 // Stop Button
                 ElevatedButton(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -97,7 +97,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -130,26 +130,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -178,10 +178,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -271,18 +271,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -300,5 +300,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/linux/CameraLinux.cpp
+++ b/linux/CameraLinux.cpp
@@ -119,6 +119,18 @@ bool Camera::SetResolution(int width, int height)
 
 FrameData Camera::CaptureFrame()
 {
+    if (fd == -1)
+    {
+        std::cerr << "Device not opened." << std::endl;
+        return {};
+    }
+
+    if (buffers == nullptr)
+    {
+        std::cerr << "Error: buffers array is not initialized." << std::endl;
+        return {};
+    }
+
     struct v4l2_buffer buf;
     memset(&buf, 0, sizeof(buf));
     buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -131,9 +143,30 @@ FrameData Camera::CaptureFrame()
         return {};
     }
 
-    // FILE *file = fopen("raw_frame.yuyv", "wb");
-    // fwrite(buffers[buf.index].start, 1, buffers[buf.index].length, file);
-    // fclose(file);
+    if (buf.index >= bufferCount)
+    {
+        std::cerr << "Error: Buffer index " << buf.index << " exceeds buffer count " << bufferCount << std::endl;
+        return {};
+    }
+
+    if (buffers[buf.index].start == nullptr)
+    {
+        std::cerr << "Error: Buffer start is null for index " << buf.index << std::endl;
+        return {};
+    }
+
+    size_t expectedSize = frameWidth * frameHeight * 2;
+    if (buffers[buf.index].length < expectedSize)
+    {
+        std::cerr << "Error: Buffer length " << buffers[buf.index].length << " is smaller than expected " << expectedSize << std::endl;
+        return {};
+    }
+
+    if ((frameWidth * frameHeight) % 2 != 0)
+    {
+        std::cerr << "Error: Total pixels must be even for YUYV conversion." << std::endl;
+        return {};
+    }
 
     // Prepare FrameData structure
     FrameData frame;

--- a/linux/CameraLinux.cpp
+++ b/linux/CameraLinux.cpp
@@ -162,9 +162,9 @@ FrameData Camera::CaptureFrame()
         return {};
     }
 
-    if ((frameWidth * frameHeight) % 2 != 0)
+    if (frameWidth % 2 != 0)
     {
-        std::cerr << "Error: Total pixels must be even for YUYV conversion." << std::endl;
+        std::cerr << "Error: Frame width must be even for YUYV conversion." << std::endl;
         return {};
     }
 


### PR DESCRIPTION
The Linux camera plugin could crash when the device negotiated a different resolution than the one requested (e.g. the driver accepted 640×480 but returned a different actual size). This adds defensive checks in CaptureFrame() before processing buffers: validates the buffer index against bufferCount, checks that buffers[buf.index].start is non-null, and verifies that the buffer length is at least frameWidth * frameHeight * 2 bytes. The example app is also updated with a camera toggle button to switch between devices.
